### PR TITLE
Normalize paths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ export const documentLinkProvider = (document: vscode.TextDocument, token: vscod
  */
 export const resolveFile = (filePath: string): string => {
     const configuration = getConfiguration();
-    filePath = filePath.replace(/\//g, path.sep);
+    filePath = standardizePath(filePath);
 
     const matchExactNamespace = (filePath: string, nsLength: number, namespace: string) => {
         return filePath.slice(0, nsLength + 1) === namespace + path.sep;
@@ -73,7 +73,7 @@ export const resolveFile = (filePath: string): string => {
         const nsLength = namespace.length;
 
         if (nsLength === 0) {
-            return `${configuration.workspacePath}${path.sep}${folderPath}${path.sep}${filePath}`;
+            return standardizePath(`${configuration.workspacePath}/${folderPath}/${filePath}`);
         }
 
         if (! matchExactNamespace(filePath, nsLength, namespace)) {
@@ -82,12 +82,16 @@ export const resolveFile = (filePath: string): string => {
 
         const filePathToResolve = filePath.replace(`${namespace}`, folderPath);
 
-        return `${configuration.workspacePath}${path.sep}${filePathToResolve}`;
+        return standardizePath(`${configuration.workspacePath}/${filePathToResolve}`);
     }
 
-    let result = `${configuration.workspacePath}${path.sep}`;
-    result += `${configuration.templatesRootPath}${path.sep}`;
+    let result = `${configuration.workspacePath}/`;
+    result += `${configuration.templatesRootPath}/`;
     result += `${filePath}`;
 
     return result;
 };
+
+const standardizePath = (filePath: string): string => {
+    return filePath.replace(/\//g, path.sep);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,8 @@ export const documentLinkProvider = (document: vscode.TextDocument, token: vscod
                 new vscode.Position(line.lineNumber, endPosition)
             );
 
-            const uri = vscode.Uri.file(resolveFile(theMatch));
+            const file = path.normalize(resolveFile(theMatch));
+            const uri = vscode.Uri.file(file);
             const link = new vscode.DocumentLink(
                 range,
                 uri
@@ -89,5 +90,5 @@ export const resolveFile = (filePath: string): string => {
     result += `${configuration.templatesRootPath}/`;
     result += `${filePath}`;
 
-    return result;
+    return path.normalize(result);
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ export const documentLinkProvider = (document: vscode.TextDocument, token: vscod
  */
 export const resolveFile = (filePath: string): string => {
     const configuration = getConfiguration();
-    filePath = standardizePath(filePath);
+    filePath = path.normalize(filePath);
 
     const matchExactNamespace = (filePath: string, nsLength: number, namespace: string) => {
         return filePath.slice(0, nsLength + 1) === namespace + path.sep;
@@ -73,7 +73,7 @@ export const resolveFile = (filePath: string): string => {
         const nsLength = namespace.length;
 
         if (nsLength === 0) {
-            return standardizePath(`${configuration.workspacePath}/${folderPath}/${filePath}`);
+            return path.normalize(`${configuration.workspacePath}/${folderPath}/${filePath}`);
         }
 
         if (! matchExactNamespace(filePath, nsLength, namespace)) {
@@ -82,7 +82,7 @@ export const resolveFile = (filePath: string): string => {
 
         const filePathToResolve = filePath.replace(`${namespace}`, folderPath);
 
-        return standardizePath(`${configuration.workspacePath}/${filePathToResolve}`);
+        return path.normalize(`${configuration.workspacePath}/${filePathToResolve}`);
     }
 
     let result = `${configuration.workspacePath}/`;
@@ -91,7 +91,3 @@ export const resolveFile = (filePath: string): string => {
 
     return result;
 };
-
-const standardizePath = (filePath: string): string => {
-    return filePath.replace(/\//g, path.sep);
-}


### PR DESCRIPTION
I found the bug, that made problems with correct path loading.

Related issue: https://github.com/Chaxwell/vscode-extension-twigLinkResolver/issues/14

Example outputted path was:
`example/folder\\some\\path`

Which resulted in failure on my pc / windows. (Somehow it still worked inside Development host)

After following update, extension seems to work correct.

Please check the changes, and pull if everything is ok. :)  